### PR TITLE
v3.0.0: Rewrite as Lit 3 + native d3 v7 web component

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,41 @@
+name: Deploy demo to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, do not cancel an in-flight one
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build:demo
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  // Relative base so the build works on GitHub Pages (served from
+  // /granite-timeline/) as well as on any other static host.
+  base: './',
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(import.meta.dirname, 'index.html'),
+        demo: resolve(import.meta.dirname, 'demo/index.html'),
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Full rewrite of `granite-timeline`, replacing the 2018 Polymer 3 + d3-timelines stack:

- **Lit 3** replaces Polymer 3
- **Native d3 v7 rendering** in `src/timeline-renderer.js` — a pure, Lit-free module — replaces the abandoned `d3-timelines` plugin (pinned to a git commit of a fork, built on d3 v4 APIs removed in v6)
- d3 is now a regular ES-module dependency (6 submodules): no more runtime script loading via `granite-js-dependencies-grabber`, no polyfills, no Bower
- Responsive redraw via `ResizeObserver`
- **New: horizontal axis zoom & pan** (`axis-zoom`): Ctrl/⌘+wheel or pinch to zoom, drag to pan, double-click to zoom in; `zoom` event reports the visible domain; `resetZoom()` restores the full view; plot area is clipped; transform persists across redraws
- Plain JavaScript + JSDoc, published as ES modules with no build step (5 files, ~11 kB tarball)
- New Vite-served demo (6 sections), ESLint 9 flat config, CHANGELOG, rewritten README with a v2 → v3 migration guide
- GitHub Pages now deploys via Actions on every push to `master` (Pages source already switched to `workflow`); merging this PR triggers the first automated deploy

## Dropped from v2 (see README migration notes)

`displayCircles`, `relativeTime`, `showBorderLine*`, `showTimeAxisTick*`, `xAxisClass`, the `scroll` event, and the redundant `i` event-detail field.

## Test plan

- Verified end-to-end in Chrome against the demo: bar geometry/stacking semantics, color resolution order (`time.color` → `colorsProperty` → scale), today line, tick configuration (`tickTime`/`tickInterval`/`tickFormat`/`rotateTicks`), axis top/bottom, events detail shape, ResizeObserver redraw (incl. detach/reattach), zoom/pan/persistence/reset, dynamic `data` reassignment
- `npm run lint` clean; `npm pack --dry-run` ships only intended files
- Live demo built from this branch: https://lostinbrittany.github.io/granite-timeline/demo/
- Follow-up (not in this PR): `@web/test-runner` smoke tests for the pure renderer

⚠️ Note: tag `3.0.0` currently points at a commit on this branch — prefer a fast-forward or merge-commit merge (not squash) so the tag stays in `master`'s history.